### PR TITLE
Add latest Laravel versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     },
     "require": {
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "guzzlehttp/guzzle": "^6.3|^7.0|^8.0|^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
Attempt to fix this version conflict:

```
dangson[~/Source/awards-submissions-v2]$ sail composer require ctbuh/laravel-salesforce-oauth dev-master
./composer.json has been updated
Running composer update ctbuh/laravel-salesforce-oauth
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires ctbuh/laravel-salesforce-oauth dev-master -> satisfiable by ctbuh/laravel-salesforce-oauth[dev-master].
    - ctbuh/laravel-salesforce-oauth dev-master requires illuminate/contracts ^6.0|^7.0|^8.0|^9.0 -> found illuminate/contracts[v6.0.0, ..., v6.20.44, v7.0.0, ..., v7.30.6, v8.0.0, ..., v8.83.27, v9.0.0, ..., v9.52.16] but these were not loaded, likely because it conflicts with another require.
```

Hopefully this will just work out of the box.